### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/rsyntaxtree.gemspec
+++ b/rsyntaxtree.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.description = %q{Yet another syntax tree generator made with Ruby and RMagick}
   s.licenses    = ["MIT"]
 
-  s.rubyforge_project = "rsyntaxtree"
-
   s.files         = `git ls-files`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.